### PR TITLE
Update default package version for libpq-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,9 @@ An Ansible role for installing libraries that support the following PostgreSQL A
 
 ## Role Variables
 
-- `postgresql_support_libpq_version` - PostgreSQL client library version (default: `9.3.5-1.pgdg14.04+1`)
+- `postgresql_support_libpq_version` - PostgreSQL client library version (default: `9.3.5-2.pgdg14.04+1`)
 - `postgresql_support_psycopg2_version` - Psycopg2 version (default: `2.5.4`)
+- `postgresql_support_repository_channel` - PostgreSQL repository channel (default: `main`)
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
-postgresql_support_libpq_version: "9.3.5-2~205.bzr460.pgdg14.04+2"
+postgresql_support_libpq_version: "9.3.5-2.pgdg14.04+1"
 postgresql_support_psycopg2_version: "2.5.4"
+postgresql_support_repository_channel: "main"

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -1,4 +1,8 @@
 ---
 - hosts: all
+
+  vars:
+    postgresql_support_repository_channel: "9.3"
+
   roles:
     - { role: "azavea.postgresql-support" }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   apt_key: url=https://www.postgresql.org/media/keys/ACCC4CF8.asc state=present
 
 - name: Configure the PostgreSQL APT repositories
-  apt_repository: repo="deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release}}-pgdg main"
+  apt_repository: repo="deb http://apt.postgresql.org/pub/repos/apt/ {{ ansible_distribution_release}}-pgdg {{ postgresql_support_repository_channel }}"
                   state=present
 
 - name: Install client API libraries for PostgreSQL


### PR DESCRIPTION
The release of PostgreSQL 9.4 pushed 9.4 related packages into the `main` repository channel and pushed 9.3 related packages to the `9.3` repository channel. This changeset adds a new attribute for PostgreSQL repository channel, which is used to set the APT repository channel.
