### PR TITLE
Glob version for install; test PostgreSQL 9.4 support

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-postgresql_support_libpq_version: "9.3.5-2.pgdg14.04+1"
-postgresql_support_psycopg2_version: "2.5.4"
+postgresql_support_libpq_version: "9.4.*.pgdg14.04+1"
+postgresql_support_psycopg2_version: "2.6"
 postgresql_support_repository_channel: "main"

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -1,8 +1,5 @@
 ---
 - hosts: all
 
-  vars:
-    postgresql_support_repository_channel: "9.3"
-
   roles:
     - { role: "azavea.postgresql-support" }

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: An Ansible role for installing libraries that support PostgreSQL Ansible modules.
   company: Azavea Inc.
   license: Apache
-  min_ansible_version: 1.2
+  min_ansible_version: 1.8
   platforms:
   - name: Ubuntu
     versions:


### PR DESCRIPTION
In the process of testing PostgreSQL 9.4 support, I also made the default version a glob for flexibility.

Depends on: azavea/ansible-postgresql#4