### PR TITLE
Update libpq to 9.5 - 9.4 is no longer available

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-postgresql_support_libpq_version: "9.4.*.pgdg14.04+1"
+postgresql_support_libpq_version: "9.5.*.pgdg14.04+2"
 postgresql_support_psycopg2_version: "2.6"
 postgresql_support_repository_channel: "main"


### PR DESCRIPTION
Provisioning in DRIVER was failing - 9.4 doesn't appear to be available any longer.