### PR TITLE
Switch example from roles.txt to roles.yml

### DIFF
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -7,7 +7,7 @@ VAGRANTFILE_API_VERSION = "2"
 if [ "up", "provision" ].include?(ARGV.first) && File.directory?("roles") &&
   !(File.directory?("roles/azavea.python") || File.symlink?("roles/azavea.python")) ||
   !(File.directory?("roles/azavea.pip") || File.symlink?("roles/azavea.pip"))
-  system("ansible-galaxy install --force -r roles.txt -p roles")
+  system("ansible-galaxy install --force -r roles.yml -p roles")
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,2 +1,2 @@
-azavea.pip,0.1.0
+azavea.pip,0.1.1
 azavea.python,0.1.0

--- a/examples/roles.txt
+++ b/examples/roles.txt
@@ -1,2 +1,0 @@
-azavea.pip,0.1.1
-azavea.python,0.1.0

--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -1,0 +1,4 @@
+- src: azavea.pip
+  version: 0.1.1
+- src: azavea.python
+  version: 0.1.0

--- a/examples/site.yml
+++ b/examples/site.yml
@@ -1,5 +1,9 @@
 ---
 - hosts: all
 
+  pre_tasks:
+    - name: Update APT cache
+      apt: update_cache=yes
+
   roles:
     - { role: "azavea.postgresql-support" }


### PR DESCRIPTION
The CSV format is deprecated as of Ansible 2.0.

This PR also updates the example ansible-pip dependency to the latest version allowing an updated APT package version can be found and installed.

##### Testing

Destroy and recreate the example VM after deleting any previously downloaded roles.

$ cd examples
$ rm -rf roles/azavea.python roles/azavea.pip
$ vagrant destroy -f && vagrant up