### PR TITLE
Change default repository channel to 9.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ An Ansible role for installing libraries that support the following PostgreSQL A
 
 ## Role Variables
 
-- `postgresql_support_libpq_version` - PostgreSQL client library version (default: `9.3.5-2.pgdg14.04+1`)
-- `postgresql_support_psycopg2_version` - Psycopg2 version (default: `2.5.4`)
-- `postgresql_support_repository_channel` - PostgreSQL repository channel (default: `main`)
+- `postgresql_support_libpq_version` - PostgreSQL client library version (default: `9.5.*.pgdg14.04+2`)
+- `postgresql_support_psycopg2_version` - Psycopg2 version (default: `2.6`)
+- `postgresql_support_repository_channel` - PostgreSQL repository channel (default: `9.5`)
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 postgresql_support_libpq_version: "9.5.*.pgdg14.04+2"
 postgresql_support_psycopg2_version: "2.6"
-postgresql_support_repository_channel: "main"
+postgresql_support_repository_channel: "9.5"


### PR DESCRIPTION
The PostgreSQL 9.6 release pushed many of the PostgreSQL 9.5 related packages out of the main channel. Those packages are now housed within the 9.5 channel.

Resolves https://github.com/azavea/ansible-postgresql-support/issues/9

---

**Testing**

Bring up the Vagrant virtual machine from the `examples` directory:

```bash
$ cd examples
$ vagrant up
```