### PR TITLE
Update libpq version glob

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-postgresql_support_libpq_version: "9.5.*.pgdg14.04+2"
+postgresql_support_libpq_version: "9.5.*.pgdg14.04+1"
 postgresql_support_psycopg2_version: "2.6"
 postgresql_support_repository_channel: "9.5"


### PR DESCRIPTION
Trailing package build version was changed, so the version glob was updated to accommodate.

Resolves https://github.com/azavea/ansible-postgresql-support/issues/11

---

**Testing**

Bring up the Vagrant virtual machine from the `examples` directory:

``` bash
$ cd examples
$ vagrant up
```
