### PR TITLE
Add Ubuntu 16.04 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 
 examples/roles/azavea.python
 examples/roles/azavea.pip
+
+*.retry

--- a/LICENSE
+++ b/LICENSE
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2018 Azavea Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/examples/roles.yml
+++ b/examples/roles.yml
@@ -1,4 +1,4 @@
 - src: azavea.pip
-  version: 0.1.1
+  version: 1.0.0
 - src: azavea.python
   version: 0.1.0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -9,6 +9,7 @@ galaxy_info:
   - name: Ubuntu
     versions:
     - trusty
+    - xenial
   categories:
   - database:sql
 dependencies:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,8 +7,11 @@
                   state=present
 
 - name: Install client API libraries for PostgreSQL
-  apt: pkg=libpq-dev={{ postgresql_support_libpq_version }}
+  apt: pkg={{ item }}={{ postgresql_support_libpq_version }}
        state=present
+  with_items:
+    - libpq5
+    - libpq-dev
 
 - name: Install PostgreSQL driver for Python
   pip: name=psycopg2


### PR DESCRIPTION
Dependency resolution for `libpq-dev` on Ubuntu 16.04 complains about the version of transitive dependency `libpq5` when you try to install it without a specific version of `libpq5` already installed.

This change set ensures that the same version of `libpq5` is installed _before_ the `libpq-dev` installation is attempted.

---

**Testing**

Apply the following diff to the current branch, navigate to the `examples` directory, and attempt to execute `vagrant up`. Ensure that it fails with an error message like:

```
TASK [azavea.postgresql-support : Install client API libraries for PostgreSQL] ***
failed: [default] (item=[u'libpq-dev=9.4.*.pgdg16.04+1']) => {"cache_update_time": 1531419397, "cache_updated": false, "changed": false, "failed": true, "item": ["libpq-dev=9.4.*.pgdg16.04+1"], "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'libpq-dev=9.4.*.pgdg16.04+1'' failed: E: Unable to correct problems, you have held broken packages.\n", "rc": 100, "stderr": "E: Unable to correct problems, you have held broken packages.\n", "stderr_lines": ["E: Unable to correct problems, you have held broken packages."], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nSome packages could not be installed. This may mean that you have\nrequested an impossible situation or if you are using the unstable\ndistribution that some required packages have not yet been created\nor been moved out of Incoming.\nThe following information may help to resolve the situation:\n\nThe following packages have unmet dependencies:\n libpq-dev : Depends: libpq5 (= 9.4.18-2.pgdg16.04+1) but 9.5.13-0ubuntu0.16.04 is to be installed\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "Some packages could not be installed. This may mean that you have", "requested an impossible situation or if you are using the unstable", "distribution that some required packages have not yet been created", "or been moved out of Incoming.", "The following information may help to resolve the situation:", "", "The following packages have unmet dependencies:", " libpq-dev : Depends: libpq5 (= 9.4.18-2.pgdg16.04+1) but 9.5.13-0ubuntu0.16.04 is to be installed"]}
        to retry, use: --limit @/Users/hcastro/Projects/ansible-postgresql-support/examples/site.retry
```

**Diff**

```diff
diff --git a/examples/Vagrantfile b/examples/Vagrantfile
index f1a3101..69f2301 100644
--- a/examples/Vagrantfile
+++ b/examples/Vagrantfile
@@ -11,7 +11,7 @@ if [ "up", "provision" ].include?(ARGV.first) && File.directory?("roles") &&
 end
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/trusty64"
+  config.vm.box = "bento/ubuntu-16.04"
 
   config.vm.provision "ansible" do |ansible|
     ansible.playbook = "site.yml"
diff --git a/examples/site.yml b/examples/site.yml
index 5dd5369..049eb80 100644
--- a/examples/site.yml
+++ b/examples/site.yml
@@ -1,6 +1,11 @@
 ---
 - hosts: all
 
+  vars:
+    python_version: "2.7.12-1~16.04"
+    postgresql_support_libpq_version: "9.4.*.pgdg16.04+1"
+    postgresql_support_repository_channel: "9.4"
+
   pre_tasks:
     - name: Update APT cache
       apt: update_cache=yes
diff --git a/tasks/main.yml b/tasks/main.yml
index 8830774..19e2683 100644
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
   apt: pkg={{ item }}={{ postgresql_support_libpq_version }}
        state=present
   with_items:
-    - libpq5
+    # - libpq5
     - libpq-dev
 
 - name: Install PostgreSQL driver for Python
```

Then, uncomment just the `libpg5` line from `tasks/main.yml` and run `vagrant provision` to ensure that it completes successfully.

Lastly, undo the entire diff, run `vagrant destroy -f`, and ensure that `vagrant up` runs cleanly (attempts to ensure backward compatibility).